### PR TITLE
Improvements from feedbacks on the latest release

### DIFF
--- a/.github/workflows/clippy-review.yml
+++ b/.github/workflows/clippy-review.yml
@@ -27,13 +27,28 @@ name: Clippy Review
 jobs:
   review:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
         with:
             toolchain: nightly
             components: clippy
             override: true
-      - uses: actions-rs/clippy-check@v1
+
+      - name: Cache cargo dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run clippy check
+        uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -27,6 +27,7 @@ name: Code Quality
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -38,6 +39,15 @@ jobs:
           toolchain: nightly
           override: true
 
+      - name: Cache cargo dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:
@@ -45,6 +55,7 @@ jobs:
 
   style:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -56,6 +67,15 @@ jobs:
           toolchain: nightly
           override: true
           components: rustfmt, clippy
+
+      - name: Cache cargo dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,14 +30,26 @@ name: Release
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           override: true
+
+      - name: Cache cargo dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
@@ -46,27 +58,40 @@ jobs:
 
   github-release:
     needs: [test]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       RUST: nightly
       TARGET: x86_64-unknown-linux-musl
       BIN: kct
       NAME: kct-linux-amd64
-    runs-on: ubuntu-latest
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ env.RUST }}
           override: true
           target: ${{ env.TARGET }}
-      - name: Checkout
-        uses: actions/checkout@v2
+
+      - name: Cache cargo dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Run build
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --bin=kct --release --target ${{ env.TARGET }}
-      - name: Package
+
+      - name: Create packages
         shell: bash
         run: |
           strip target/${{ env.TARGET }}/release/${{ env.BIN }}
@@ -74,8 +99,10 @@ jobs:
 
           cp ${{ env.BIN }} ../../../${{ env.NAME }}
           cd -
+
       - name: Generate SHA-256
         run: shasum -a 256 ${{ env.NAME }} > ${{ env.NAME }}.sha256
+
       - name: Publish
         uses: softprops/action-gh-release@v1
         with:
@@ -87,26 +114,41 @@ jobs:
   cargo-release:
     needs: [test]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           override: true
-      - name: Checkout
-        uses: actions/checkout@v2
+
+      - name: Cache cargo dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Run cargo login
         uses: actions-rs/cargo@v1
         with:
           command: login
           args: ${{ secrets.CARGO_TOKEN }}
+
       - name: Publish crates
         shell: bash
         run: |
           crates=('helper' 'kube' 'package')
           for crate in ${crates[@]}; do
             cargo publish --manifest-path="crates/kct_$crate/Cargo.toml"
+            sleep 60
           done
+
       - name: Publish binary
         uses: actions-rs/cargo@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- documentation about motivation, usage, and package structure
+
+### Fixed
+
+- unwanted print on when validating values
+- wrong package version on `--version`
+
 ## [0.2.0] - 2020-10-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,53 +1,29 @@
 # Kubernetes Configuration Tool
 
-> No more context babysitting or hideous templates
+![build](https://img.shields.io/github/workflow/status/kseat/kct/Code%20Quality)
+![license](https://img.shields.io/crates/l/kct)
+![version](https://img.shields.io/crates/v/kct?label=version)
 
-A combination from Helm + Tanka for the best of both worlds.
+KCT is a tool for taming the Kubernetes configuration beast by using Jsonnet while borrowing approaches and concepts from early contestants such as Tanka and Helm.
 
-## Motivation
-
-Inspired by the [current state of Kubernetes configuration management](https://blog.argoproj.io/the-state-of-kubernetes-configuration-management-d8b06c1205), I'm giving my take on this matter. I created this in an effort to run away from [hideous](https://helm.sh/)/[complex](https://kapitan.dev/) templates and [context](https://qbec.io/)/[cluster](https://tanka.dev/) babysitting.
-
-By combining the value injection from Helm with the Jsonnet template engine from Tanka, I intend to have a tool that doesn't have static configurations through files but through CLI parameters. Although, differently from Helm alternatives, I still want to trust the developer for context and cluster switching and having the tool only manage packages and their installation on clusters of choice. And taking inspiration from Tanka, I choose Jsonnet since it's a data templating language, instead of the [ugly YAML templating](http://leebriggs.co.uk/blog/2019/02/07/why-are-we-templating-yaml.html), and have mechanisms aiming at object extension/patching which helps with the extension problems of charts from Helm.
+**NOTICE: This project is under heavy development. Despite the 0.x.y releases being "production ready", don't expect API stability before a 1.0 release as [anything may change](https://semver.org/#spec-item-4) due to experimentation and feedback.**
 
 ## Installation
 
 There are three ways you can install our tool:
 
-- From the binary releases that can be found on the [Releases Page](https://github.com/bruno-delfino1995/kct/releases) and adding the bin to your `$PATH`
+- By adding a binary releases from the [Releases Page](https://github.com/bruno-delfino1995/kct/releases) to your `$PATH`
 - By installing the binary at [crates.io](https://crates.io/crates/kct) with `cargo install kct`
 - Through your prefered package manager for your distro:
   - Arch user with `yay -S kct`
 
-## Usage
+## Documentation
 
-As we are at the early stages of the project we only provide one command to help you manage your kubernetes objects, although it's up to you how you'll install them.
-
-The recommended usage boils down to compiling with `kct` and installing with `kubectl`:
-
-``` bash
-# install
-kct compile kcp -f values.json | kubectl apply -f -
-# uninstall
-kct compile kcp -f values.json | kubectl delete -f -
-```
-
-These commands act upon what we called __Kubernetes Configuration Packages (KCP)__ which are collections of templates to build your K8s objects.
-
-### Kubernetes Configuration Packages
-
-This is the "configuration unit" for `kct` much like what __Charts__ are to `helm`.
-
-The requirements for a KCP are:
-
-- A `kcp.json` file describing the package
-- A `values.schema.json` if you intend to receive values
-
-We still don't have a mechanism to load Jsonnet libraries and for that we recommend [Jsonnet Bundler](https://github.com/jsonnet-bundler/jsonnet-bundler) at the moment. Jsonnet bundler also helps with subpackages because a KCP is only a collection of jsonnet files, you just have to import the correct entrypoint and you're ready to go.
+If you want to know more about the tool's components and inner workings, take a look at the [documentation](./docs/index.md). There you'll find description on the [package](./docs/kcp.md) structure and feature, along the [commands](./docs/usage.md) with brief explanations about their tasks.
 
 ## Contributing
 
-Any contribution is welcome, be either an issue or a PR. I'm very new to Rust so anything in the code that seems wrong feel free to point it out, your contribution will be very helpful to raise the bar and help my evolution.
+Any contribution is welcome, be either an issue or a PR. I'm very new to Rust so anything in the code that seems wrong feel free to point it out.
 
 ## LICENSE
 

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -5,6 +5,8 @@ use clap::{App, ArgMatches};
 use std::error::Error;
 use thiserror::Error;
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 #[derive(Error, Debug, PartialEq)]
 pub enum CliError {
 	#[error("Unknown command or args combination")]
@@ -13,8 +15,8 @@ pub enum CliError {
 
 pub fn create() -> App<'static, 'static> {
 	App::new("Kubernetes Configuration Tool")
-		.version("0.1.0")
-		.about("K8S config without hideous templates or context babysitting")
+		.version(VERSION)
+		.about("K8s config without hideous templates or context babysitting")
 		.subcommand(compile::command())
 		.subcommand(package::command())
 }

--- a/crates/kct_package/src/lib.rs
+++ b/crates/kct_package/src/lib.rs
@@ -140,7 +140,6 @@ fn validate_values(schema: &Option<Schema>, values: &Option<Value>) -> Result<()
 	if values.is_object() && schema.validate(&values) {
 		Ok(())
 	} else {
-		println!("Values = {}", values);
 		Err(Error::InvalidValues)
 	}
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,34 @@
+# Welcome
+
+Welcome to the KCT wiki!
+
+Here lives our initial documentation about concepts and how the project works
+
+<a name="about"></a>
+
+## About
+
+KCT is a tool for taming the Kubernetes configuration beast by using [Jsonnet](http://jsonnet.org/) while borrowing approaches and concepts from early contestants such as [Tanka](https://helm.sh/) and [Helm](https://helm.sh/).
+
+<a name="motivation"></a>
+
+## Motivation
+
+The motivation came from ["The State of Kubernetes Configuration Management: An Unsolved Problem"][state-k8s-config] and ["Why the fuck are we templating YAML?"][hideous-templates]. In this project, we avoid [hideous](https://helm.sh/)/[complex](https://kapitan.dev/) templates and [context](https://qbec.io/)/[cluster](https://tanka.dev/) management, those achieved by using Jsonnet as a template engine and leveraging kubeconfig for cluster access.
+
+We want to trust the users with context and cluster access, by using their [preffered tools](https://github.com/ahmetb/kubectx) to manage kubeconfig, while focusing on the creation of the resources with a better templating language.
+
+<a name="acknowledgments"></a>
+
+## Roadmap
+
+We don't have a clear set of features we want to have, but we do have the path we want to take. You can get a glimpse of such path by looking at our [milestones](https://github.com/kseat/kct/milestones). As summary, we're aspiring to be a Helm alternative but with: optional releases, file templating, Jsonnet, build stages, and more.
+
+## Acknowledgments
+
+Once this project wouldn't be possible without their parser and evaluator, I owe special thanks to the creators of [jrsonnet](https://github.com/CertainLach/jrsonnet).
+
+Thanks to the ArgoCD project for their post, and thanks to the creators of the reviewed tools. I wouldn't be able to know at which features I should aim without their review and prior approaches.
+
+[state-k8s-config]: https://blog.argoproj.io/the-state-of-kubernetes-configuration-management-d8b06c1205
+[hideous-templates]: http://leebriggs.co.uk/blog/2019/02/07/why-are-we-templating-yaml.html

--- a/docs/kcp.md
+++ b/docs/kcp.md
@@ -1,0 +1,170 @@
+# Kubernetes Configuration Package (KCP)
+
+The package structure defined by KCT to build your K8s objects.
+
+<a name="structure"></a>
+
+## Structure
+
+A KCP is any directory or `.tgz` file that inside has the following structure:
+
+```text
+kcp[.tgz]/
+├── kcp.json            # manifest file
+├── templates/          # directory for your Jsonnet templates
+│   └── main.jsonnet    # compilation entrypoint
+├── values.json         # OPTIONAL: default values
+├── values.schema.json  # OPTIONAL: schema to validate your values
+├── lib/                # OPTIONAL: aliases or internal libs
+├── vendor/             # OPTIONAL: external libs managed by Jsonnet Bundler
+└── files/              # OPTIONAL: files to be compiled by Tera
+└── kcps/               # OPTIONAL: (pending) subpackages that you can include
+```
+
+The minimal structure consists of the manifest file (`kcp.json`) and the compilation entrypoint (`templates/main.jsonnet`). For values we have `values.schema.json` and `values.json` as mutual dependents. For libraries, there're `vendor` and `lib` mirroring the concepts from [Tanka](https://tanka.dev/libraries/import-paths). For general files, a name borrowed from [Helm](https://helm.sh/docs/chart_template_guide/accessing_files/#helm), that you might want to include, there's the `files` directory; however, differently from Helm, these are rendered by [Tera](https://tera.netlify.app/docs). And finally, there's the `kcps` directory which contains the packages declared in your manifest as dependencies
+
+To have a better grasp of the structure and features, take a look at the [example package][example-kcp] that we use for testing
+
+## Manifest Format
+
+As we're talking about Jsonnet and not Yamlnet, I've decided to use a simple JSON file with the following properties:
+
+```json
+{
+	"name": "kcp",
+	"version": "1.0.0",
+	"dependencies": {
+		"prometheus": { "version": "1.1.0", "path": "https://repo.com/packages/prometheus" }
+	}
+}
+```
+
+In this example, we've declared a package named `kcp` at version `1.0.0` which depends upon `prometheus` on `1.1.0` stored at `http://repo.com/packages/prometheus/prometheus_1.1.0.tgz`.
+
+You might be wondering, what about Jsonnet dependencies? For this job we recommend [Jsonnet Bundler](https://github.com/jsonnet-bundler/jsonnet-bundler). We wanted to refactor imports to have a mechanism alike Node.JS but this would break the existing libraries such as [ksonnet](https://github.com/ksonnet/ksonnet-lib) and [kausal](https://github.com/grafana/jsonnet-libs/tree/master/ksonnet-util).
+
+<a name="built-in"></a>
+
+## Built-in Objects
+
+To aid developers with external info and utilities, we inject the `_` global into your templates. Within this global each property fulfills a specific purpose. The global structure consists of:
+
+- `values`: injected values that are the result of merging your defaults with values provided during compilation
+- `files`: a function that receives a blob and will return a list with the contents of rendered files
+- `include`: (pending) a function that receives a package name and an object for values and will return the rendered subpackage
+- `package`: information about your package that can help you scope your resources
+	- `name`: the package names as in the manifest file
+	- `fullName`: your package name prefixed by the release name - use this as your prefix in the templates
+- `release`: information about the release being manipulated
+	- `name`: the name provided when compiling
+
+##
+
+<a name="objects"></a>
+
+## Objects
+
+The sole goal of a KCP is to render the necessary [resources][k8s-objects] into K8s. These resources are defined by the KCP developer and found by the tool walking down the object properties until it finds the [required fields][k8s-required-fields] of an object (note that we don't check for `spec` once [secrets don't use it][k8s-secret]). For instance, the following template would render a set of objects:
+
+```jsonnet
+{
+  // Grafana
+  grafana: {
+    deployment: {
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+      metadata: {
+        name: 'grafana',
+      }, // ...
+    },
+    service: {
+      apiVersion: 'v1',
+      kind: 'Service',
+      metadata: {
+        name: 'grafana',
+      }, // ...
+    },
+  },
+
+  // Prometheus
+  prometheus: {
+    deployment: {
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+      metadata: {
+        name: 'prometheus',
+      }, // ...
+    },
+    service: {
+      apiVersion: 'v1',
+      kind: 'Service',
+      metadata: {
+        name: 'prometheus',
+      }, // ...
+    },
+  },
+}
+```
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+# ...
+---
+apiVersion: apps/v1
+kind: Service
+metadata:
+  name: grafana
+# ...
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+# ...
+---
+apiVersion: apps/v1
+kind: Service
+metadata:
+  name: prometheus
+# ...
+```
+
+### Extensibility
+
+By leveraging Jsonnet as our data template engine, we get operators such as the [object composition][jsonnet-oo] that allow a developer to override configs defined in other packages. With this operator at hand and subpackages, we enable patterns such as:
+
+```jsonnet
+_.include('grafana') + {
+	deployment+: {
+		spec+: {
+			replicas: 2
+		}
+	}
+}
+```
+
+Which results in the override of a specific property without duplicating everything. That also highlights that your rendered structure is the API for your package, and since arrays are harder to extend, **we don't allow arrays in the API**. With this constraint, the pattern below is disallowed:
+
+```jsonnet
+{
+	deployments: [
+		{ metadata: { name: "grafana" } },
+		{ metadata: { name: "prometheus" } },
+	],
+	services: [
+		{ metadata: { name: "grafana" } },
+		{ metadata: { name: "prometheus" } },
+	]
+}
+```
+
+Where the "deliverables" get hidden behind K8s concepts, difficulting extension and blurrying the components of the package. Although, note that if a package only has one component that consists of a deployment and a service, don't bother finding terms to abstract K8s, we're managing K8s anyway.
+
+[jsonnet-oo]: https://jsonnet.org/learning/tutorial.html#oo
+[k8s-objects]: https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/
+[k8s-required-fields]: https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields
+[k8s-secret]: https://kubernetes.io/docs/concepts/configuration/secret/
+[example-kcp]: https://github.com/kseat/kct/tree/master/crates/kct_package/tests/fixtures/kcp

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,42 @@
+# Usage
+
+KCT consists of a CLI which acts upon a specific directory structure named [Kubernetes Configuration Package][kcp]. Here we describe the commands in depth, but remember that there's always `--help` there for you. If you're looking for what you can use within your package, check out the [package documentation][kcp]
+
+<a name="compile"></a>
+
+## Compile
+
+Extract the [Kubernetes objects][compile-objects] from the compiled JSON into STDOUT.
+
+It starts by validating your package, as any other command, then goes to validate the merged results of default values and provided values, if everything is valid it'll try to compile your package. Once the package is compiled into the structure defined by your templates, we extract the objects by [walking the paths][kcp-objects] and render that to STDOUT by using the `List` kind from `kubectl`.
+
+The compilation lives at the core because it's how a package becomes a set of resources, so it's our main focus and most primitive resource. The most basic usage of this command is to feed `kubectl` with the resource definitions to manipulate, as we show below by applying and then deleting the compilation results.
+
+``` bash
+# install
+kct compile kcp -f values.json | kubectl apply -f -
+
+# uninstall
+kct compile kcp -f values.json | kubectl delete -f -
+```
+
+<a name="package"></a>
+
+## Package
+
+Package the KCP directory into a KCP archive (aka, a `tgz` file.)
+
+This command is geared towards publishing and sharing packages in an easy way. It simply validates the package against the minimal [structure][kcp-structure], and once the package is valid you'll get a `tar.gz` file compacted into your _CWD_. The newly created archive will have a name consisting of `<name>_<version>.tgz`. With your archive you can then share with your peers or even compile it.
+
+```bash
+# create archive
+kct package kcp
+
+# compile archive
+kct compile kcp_1.0.0.tgz -f values.json | kubectl apply -f -
+```
+
+[compile-objects]: https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/
+[kcp-structure]: ./kcp.md#structure
+[kcp-objects]: ./kcp.md#objects
+[kcp]: ./kcp.md


### PR DESCRIPTION
These changes fix the problems we had while releasing version 0.2.0, such as:

- zombie pipeline that kept running forever
- bin release failed due to a "stale" index
- wrong version on command prompt
- unwanted print for values validation errors

Along with those, I've also added caches to our pipelines so they will hopefully run faster.