### PR TITLE
Add function to render subpackages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - documentation about motivation, usage, and package structure
+- `include` function to render a subpackage under `kcps` with the provided values
 
 ### Fixed
 

--- a/crates/kct_package/src/compile.rs
+++ b/crates/kct_package/src/compile.rs
@@ -1,28 +1,29 @@
+mod file;
+mod subpackage;
+
 use crate::error::{Error, Result};
 use crate::Package;
-use globwalk::{DirEntry, GlobWalkerBuilder};
 use jrsonnet_evaluator::{
 	error::Error as JrError,
 	error::LocError,
-	native::NativeCallback,
 	trace::{ExplainingFormat, PathResolver},
-	EvaluationState, FileImportResolver, FuncVal, LazyBinding, LazyVal, ObjMember, ObjValue, Val,
+	EvaluationState, FileImportResolver, LazyBinding, LazyVal, ObjMember, ObjValue, Val,
 };
-use jrsonnet_parser::{Param, ParamsDesc, Visibility};
+use jrsonnet_parser::Visibility;
 use serde_json::{Map, Value};
 use std::collections::HashMap;
-use std::fs;
-use std::path::PathBuf;
 use std::rc::Rc;
-use tera::{Context, Tera};
 
-const FILES_PARAM: &str = "files";
-const PACKAGE_PARAM: &str = "package";
-const RELEASE_PARAM: &str = "release";
-const VALUES_PARAM: &str = "values";
-const TEMPLATES_FOLDER: &str = "files";
-const GLOBAL_VARIABLE: &str = "_";
+pub const FILES_PARAM: &str = "files";
+pub const INCLUDE_PARAM: &str = "include";
+pub const PACKAGE_PARAM: &str = "package";
+pub const RELEASE_PARAM: &str = "release";
+pub const VALUES_PARAM: &str = "values";
+pub const TEMPLATES_FOLDER: &str = "files";
+pub const SUBPACKAGES_FOLDER: &str = "kcps";
+pub const GLOBAL_VARIABLE: &str = "_";
 
+#[derive(Clone, Debug)]
 pub struct Release {
 	pub name: String,
 }
@@ -84,7 +85,8 @@ fn create_state(pkg: &Package) -> EvaluationState {
 }
 
 fn create_global(pkg: &Package, values: &Value, release: &Option<Release>) -> Val {
-	let files = create_files_func(&pkg, values);
+	let files = file::create_function(pkg, values);
+	let include = subpackage::create_function(pkg, release);
 	let values = Val::from(values);
 	let package = {
 		let mut map = Map::<String, Value>::new();
@@ -121,6 +123,7 @@ fn create_global(pkg: &Package, values: &Value, release: &Option<Release>) -> Va
 		(PACKAGE_PARAM, package),
 		(RELEASE_PARAM, release),
 		(VALUES_PARAM, values),
+		(INCLUDE_PARAM, include),
 	];
 
 	let entries: HashMap<Rc<str>, ObjMember> = pairs
@@ -139,90 +142,4 @@ fn create_global(pkg: &Package, values: &Value, release: &Option<Release>) -> Va
 		.collect();
 
 	Val::Obj(ObjValue::new(None, Rc::new(entries)))
-}
-
-fn create_files_func(pkg: &Package, values: &Value) -> Val {
-	let params = ParamsDesc(Rc::new(vec![Param("name".into(), None)]));
-
-	let root = pkg.root.clone();
-	let values = values.clone();
-	let render = move |params: &[Val]| -> std::result::Result<Val, LocError> {
-		let name = params.get(0).unwrap();
-		let file = match name {
-			Val::Str(name) => name,
-			_ => {
-				return Err(LocError::new(JrError::AssertionFailed(
-					"name should be a string".into(),
-				)))
-			}
-		};
-
-		let compiled = compile_template(&root, file, &values)
-			.map_err(|err| LocError::new(JrError::RuntimeError(err.into())))?;
-
-		if compiled.is_empty() {
-			Err(LocError::new(JrError::RuntimeError(
-				format!("No template found for glob {}", file).into(),
-			)))
-		} else if compiled.len() == 1 {
-			Ok(Val::Str(compiled.into_iter().next().unwrap().into()))
-		} else {
-			Ok(Val::Arr(
-				compiled
-					.into_iter()
-					.map(|comp| Val::Str(comp.into()))
-					.collect::<Vec<Val>>()
-					.into(),
-			))
-		}
-	};
-
-	let func = NativeCallback::new(params, render);
-	let ext: Rc<FuncVal> = FuncVal::NativeExt(FILES_PARAM.into(), func.into()).into();
-
-	Val::Func(ext)
-}
-
-fn compile_template(
-	root: &PathBuf,
-	glob: &str,
-	values: &Value,
-) -> std::result::Result<Vec<String>, String> {
-	let mut templates_dir = root.clone();
-	templates_dir.push(TEMPLATES_FOLDER);
-
-	if !templates_dir.exists() {
-		return Err(String::from("No files folder to search for templates"));
-	}
-
-	let globwalker = GlobWalkerBuilder::new(templates_dir, glob)
-		.build()
-		.map_err(|err| format!("Invalid glob provided ({}): {}", glob, err))?;
-
-	let entries: Vec<DirEntry> = globwalker
-		.collect::<std::result::Result<_, _>>()
-		.map_err(|err| format!("Unable to resolve globs: {}", err))?;
-
-	let mut paths: Vec<PathBuf> = entries.into_iter().map(DirEntry::into_path).collect();
-
-	paths.sort();
-
-	let contents: Vec<String> = paths
-		.into_iter()
-		.map(fs::read_to_string)
-		.collect::<std::result::Result<_, _>>()
-		.map_err(|err| format!("Unable to read templates: {}", err))?;
-
-	let context = match values {
-		Value::Null => Context::from_serialize(Value::Object(Map::new())).unwrap(),
-		_ => Context::from_serialize(values).unwrap(),
-	};
-
-	let compiled: Vec<String> = contents
-		.into_iter()
-		.map(|content| Tera::one_off(&content, &context, true))
-		.collect::<std::result::Result<_, _>>()
-		.map_err(|err| format!("Unable to compile templates: {}", err))?;
-
-	Ok(compiled)
 }

--- a/crates/kct_package/src/compile/file.rs
+++ b/crates/kct_package/src/compile/file.rs
@@ -1,0 +1,98 @@
+use super::{FILES_PARAM, TEMPLATES_FOLDER};
+use crate::Package;
+use globwalk::{DirEntry, GlobWalkerBuilder};
+use jrsonnet_evaluator::{
+	error::Error as JrError, error::LocError, native::NativeCallback, FuncVal, Val,
+};
+use jrsonnet_parser::{Param, ParamsDesc};
+use serde_json::{Map, Value};
+use std::fs;
+use std::path::PathBuf;
+use std::rc::Rc;
+use tera::{Context, Tera};
+
+pub fn create_function(pkg: &Package, values: &Value) -> Val {
+	let params = ParamsDesc(Rc::new(vec![Param("name".into(), None)]));
+
+	let root = pkg.root.clone();
+	let values = values.clone();
+	let render = move |params: &[Val]| -> std::result::Result<Val, LocError> {
+		let name = params.get(0).unwrap();
+		let file = match name {
+			Val::Str(name) => name,
+			_ => {
+				return Err(LocError::new(JrError::AssertionFailed(
+					"name should be a string".into(),
+				)))
+			}
+		};
+
+		let compiled = compile_template(&root, file, &values)
+			.map_err(|err| LocError::new(JrError::RuntimeError(err.into())))?;
+
+		if compiled.is_empty() {
+			Err(LocError::new(JrError::RuntimeError(
+				format!("No template found for glob {}", file).into(),
+			)))
+		} else if compiled.len() == 1 {
+			Ok(Val::Str(compiled.into_iter().next().unwrap().into()))
+		} else {
+			Ok(Val::Arr(
+				compiled
+					.into_iter()
+					.map(|comp| Val::Str(comp.into()))
+					.collect::<Vec<Val>>()
+					.into(),
+			))
+		}
+	};
+
+	let func = NativeCallback::new(params, render);
+	let ext: Rc<FuncVal> = FuncVal::NativeExt(FILES_PARAM.into(), func.into()).into();
+
+	Val::Func(ext)
+}
+
+fn compile_template(
+	root: &PathBuf,
+	glob: &str,
+	values: &Value,
+) -> std::result::Result<Vec<String>, String> {
+	let mut templates_dir = root.clone();
+	templates_dir.push(TEMPLATES_FOLDER);
+
+	if !templates_dir.exists() {
+		return Err(String::from("No files folder to search for templates"));
+	}
+
+	let globwalker = GlobWalkerBuilder::new(templates_dir, glob)
+		.build()
+		.map_err(|err| format!("Invalid glob provided ({}): {}", glob, err))?;
+
+	let entries: Vec<DirEntry> = globwalker
+		.collect::<std::result::Result<_, _>>()
+		.map_err(|err| format!("Unable to resolve globs: {}", err))?;
+
+	let mut paths: Vec<PathBuf> = entries.into_iter().map(DirEntry::into_path).collect();
+
+	paths.sort();
+
+	let contents: Vec<String> = paths
+		.into_iter()
+		.map(fs::read_to_string)
+		.collect::<std::result::Result<_, _>>()
+		.map_err(|err| format!("Unable to read templates: {}", err))?;
+
+	let context = match values {
+		Value::Null => Context::from_serialize(Value::Object(Map::new())).unwrap(),
+		_ => Context::from_serialize(values).unwrap(),
+	};
+
+	let compiled: Vec<String> = contents
+		.into_iter()
+		.map(|content| Tera::one_off(&content, &context, true))
+		.collect::<std::result::Result<_, _>>()
+		.map_err(|err| format!("Unable to compile templates: {}", err))?;
+
+	Ok(compiled)
+}

--- a/crates/kct_package/src/compile/subpackage.rs
+++ b/crates/kct_package/src/compile/subpackage.rs
@@ -1,0 +1,50 @@
+use super::{Release, INCLUDE_PARAM, SUBPACKAGES_FOLDER};
+use crate::Package;
+use jrsonnet_evaluator::{
+	error::Error as JrError, error::LocError, native::NativeCallback, FuncVal, Val,
+};
+use jrsonnet_parser::{Param, ParamsDesc};
+use serde_json::Value;
+use std::rc::Rc;
+
+pub fn create_function(pkg: &Package, release: &Option<Release>) -> Val {
+	let params = ParamsDesc(Rc::new(vec![
+		Param("name".into(), None),
+		Param("values".into(), None),
+	]));
+
+	let root = pkg.root.clone().join(SUBPACKAGES_FOLDER);
+	let release = release.clone();
+	let render = move |params: &[Val]| -> std::result::Result<Val, LocError> {
+		let name = params.get(0).unwrap();
+		let package = match name {
+			Val::Str(name) => name,
+			_ => {
+				return Err(LocError::new(JrError::AssertionFailed(
+					"name should be a string".into(),
+				)))
+			}
+		};
+		let mut root = root.join(&package.to_string());
+		root.set_extension("tgz");
+
+		let package = Package::from_path(root)
+			.map_err(|err| LocError::new(JrError::RuntimeError(err.to_string().into())))?;
+
+		let values: Option<Value> = params
+			.get(1)
+			.map(|val| val.to_string().unwrap())
+			.map(|val| serde_json::from_str(&val).unwrap());
+
+		let rendered = package
+			.compile(values, release.clone())
+			.map_err(|err| LocError::new(JrError::RuntimeError(err.to_string().into())))?;
+
+		Ok(Val::from(&rendered))
+	};
+
+	let func = NativeCallback::new(params, render);
+	let ext: Rc<FuncVal> = FuncVal::NativeExt(INCLUDE_PARAM.into(), func.into()).into();
+
+	Val::Func(ext)
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,11 +18,13 @@ The motivation came from ["The State of Kubernetes Configuration Management: An 
 
 We want to trust the users with context and cluster access, by using their [preffered tools](https://github.com/ahmetb/kubectx) to manage kubeconfig, while focusing on the creation of the resources with a better templating language.
 
-<a name="acknowledgments"></a>
+<a name="roadmap"></a>
 
 ## Roadmap
 
 We don't have a clear set of features we want to have, but we do have the path we want to take. You can get a glimpse of such path by looking at our [milestones](https://github.com/kseat/kct/milestones). As summary, we're aspiring to be a Helm alternative but with: optional releases, file templating, Jsonnet, build stages, and more.
+
+<a name="acknowledgments"></a>
 
 ## Acknowledgments
 

--- a/docs/kcp.md
+++ b/docs/kcp.md
@@ -18,12 +18,14 @@ kcp[.tgz]/
 ├── lib/                # OPTIONAL: aliases or internal libs
 ├── vendor/             # OPTIONAL: external libs managed by Jsonnet Bundler
 └── files/              # OPTIONAL: files to be compiled by Tera
-└── kcps/               # OPTIONAL: (pending) subpackages that you can include
+└── kcps/               # OPTIONAL: subpackages that you can include
 ```
 
 The minimal structure consists of the manifest file (`kcp.json`) and the compilation entrypoint (`templates/main.jsonnet`). For values we have `values.schema.json` and `values.json` as mutual dependents. For libraries, there're `vendor` and `lib` mirroring the concepts from [Tanka](https://tanka.dev/libraries/import-paths). For general files, a name borrowed from [Helm](https://helm.sh/docs/chart_template_guide/accessing_files/#helm), that you might want to include, there's the `files` directory; however, differently from Helm, these are rendered by [Tera](https://tera.netlify.app/docs). And finally, there's the `kcps` directory which contains the packages declared in your manifest as dependencies
 
 To have a better grasp of the structure and features, take a look at the [example package][example-kcp] that we use for testing
+
+<a name="manifest"></a>
 
 ## Manifest Format
 
@@ -51,14 +53,12 @@ To aid developers with external info and utilities, we inject the `_` global int
 
 - `values`: injected values that are the result of merging your defaults with values provided during compilation
 - `files`: a function that receives a blob and will return a list with the contents of rendered files
-- `include`: (pending) a function that receives a package name and an object for values and will return the rendered subpackage
+- `include`: a function that receives a package name and an object for values and will return the rendered subpackage
 - `package`: information about your package that can help you scope your resources
 	- `name`: the package names as in the manifest file
 	- `fullName`: your package name prefixed by the release name - use this as your prefix in the templates
 - `release`: information about the release being manipulated
 	- `name`: the name provided when compiling
-
-##
 
 <a name="objects"></a>
 
@@ -131,6 +131,8 @@ metadata:
   name: prometheus
 # ...
 ```
+
+<a name="objects--extensibility"></a>
 
 ### Extensibility
 


### PR DESCRIPTION
As many packages may depend on others to deploy fully functional
components, I'm introducing the `include` function in the global, which
will render any `<name>.tgz` under `<root>/kcps` with the provided
values. Along with that, I split the functions `files` and `include`
into separate modules to unclutter the compile module.

Close: #16